### PR TITLE
Add support for SSL >= 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 /lib/**/*.so
 /pkg/
 /tmp/
+*.o
+*.so
+Makefile
+mkmf.log


### PR DESCRIPTION
Hi, so not sure if this gem is still maintained, but I just tried to use it only to find it doesn't support `openssl` 1.1. 

So I updated it. 

Need to see if this passes CI (I don't have a setup with the 1.0 version), but this works for me.